### PR TITLE
Enable logging of all different kinds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "categories": [
     "Programming Languages"
   ],
+  "activationEvents": [
+    "onLanguage:assemblyscript"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,6 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as path from "path";
 import { workspace, ExtensionContext } from "vscode";
+import * as vscode from "vscode";
 import {
   ServerOptions,
   TransportKind,
@@ -10,9 +11,14 @@ import {
 } from "vscode-languageclient";
 // import * as langtypes from "vscode-languageserver-types";
 
+vscode.window.showInformationMessage("Extension context entered!");
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: ExtensionContext) {
+  const outputChannel = vscode.window.createOutputChannel(
+    "AssemblyScript Language Server"
+  );
+
   // The server is implemented in another project and outputted there
   let serverModule = context.asAbsolutePath(
     path.join("lib", "server", "index.js")
@@ -41,9 +47,17 @@ export function activate(context: ExtensionContext) {
       // Synchronize the section 'assemblyScriptLanguageServer' of the settings to the server
       configurationSection: "assemblyScriptLanguageServer",
       // Notify the server about file changes to '.clientrc files contained in the workspace
-      fileEvents: workspace.createFileSystemWatcher("**/.asc"),
+      fileEvents: [
+        workspace.createFileSystemWatcher("assembly/**/*.asc"),
+        workspace.createFileSystemWatcher("assembly/**/*.ts"),
+        workspace.createFileSystemWatcher("package.json"),
+      ],
     },
+    outputChannelName: "AssemblyScript Language Server",
   };
+
+  outputChannel.appendLine("Client Intiated!");
+  outputChannel.show(true);
 
   // Create the language client and start the client.
   let disposable = new LanguageClient(
@@ -55,7 +69,7 @@ export function activate(context: ExtensionContext) {
 
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
-  context.subscriptions.push(disposable);
+  context.subscriptions.push(disposable, outputChannel);
 }
 
 // this method is called when your extension is deactivated

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello server");


### PR DESCRIPTION
This works now

The key to get the `activate()` function to run lies in the `package.json` file.

```json
{
  "activationEvent": "onLanguage:assemblyscript"
}
```

I am really excited about this.